### PR TITLE
fix: Use `plt.colormaps.get_cmap` instead of `plt.cm.get_cmap`

### DIFF
--- a/randimage/coloredpath.py
+++ b/randimage/coloredpath.py
@@ -10,10 +10,9 @@ class ColoredPath:
 
     def get_colored_path(self, cmap=None):
         if cmap is None: cmap = random.choice(self.COLORMAPS)
-        mpl_cmap = plt.cm.get_cmap(cmap)
+        mpl_cmap = plt.colormaps.get_cmap(cmap)
         path_length = len(self.path)
         for idx,point in enumerate(self.path):
             self.img[point] = mpl_cmap(idx/path_length)[:3]
         return self.img
-
 


### PR DESCRIPTION
Thanks for the great package!
I love that this package can generate artistic images compared to the usual random image generation packages.

But as noted in issue #7, this package no longer works with the latest version of matplotlib.

`get_random_image` fail if installed using the normal installation with pip.

This function works by using `plt.cm.get_cmap` instead of `plt.colormaps.get_cmap`.