### PR TITLE
optimize `ColoredPath`

### DIFF
--- a/randimage/coloredpath.py
+++ b/randimage/coloredpath.py
@@ -12,7 +12,9 @@ class ColoredPath:
         if cmap is None: cmap = random.choice(self.COLORMAPS)
         mpl_cmap = plt.colormaps.get_cmap(cmap)
         path_length = len(self.path)
-        for idx,point in enumerate(self.path):
-            self.img[point] = mpl_cmap(idx/path_length)[:3]
+        indices = np.arange(path_length) / path_length
+        colors = mpl_cmap(indices)[:, :3]
+        for idx, point in enumerate(self.path):
+            self.img[point] = colors[idx]
         return self.img
 


### PR DESCRIPTION
Thank you for this awesome package! I love it.
I’ve been using it to generate default icons for my service, but the generation speed was becoming a bit of an issue, so I tried improving it.

With this small change to `ColoredPath`, the runtime improves dramatically. Benchmarks from the script are shown below:

| Image Size | Old (ms) | New (ms) | Speedup |
|------------|----------|----------|---------|
| 128×128    | 114.0    | 3.6      | 32.0×   |
| 256×256    | 456.0    | 14.5     | 31.5×   |
| 512×512    | 1838.9   | 55.3     | 33.3×   |

<details>

<summary> Benchmark Script </summary>

```python3
import random
import numpy as np
import matplotlib.pyplot as plt
import time

class ColoredPathOld:
    COLORMAPS = plt.colormaps()
    def __init__(self, path, shape):
        self.path = path
        self.img = np.zeros((shape[0], shape[1], 3))

    def get_colored_path(self, cmap=None):
        if cmap is None:
            cmap = random.choice(self.COLORMAPS)
        mpl_cmap = plt.colormaps.get_cmap(cmap)
        path_length = len(self.path)
        for idx, point in enumerate(self.path):
            self.img[point] = mpl_cmap(idx/path_length)[:3]
        return self.img

class ColoredPathNew:
    COLORMAPS = plt.colormaps()
    def __init__(self, path, shape):
        self.path = path
        self.img = np.zeros((shape[0], shape[1], 3))

    def get_colored_path(self, cmap=None):
        if cmap is None:
            cmap = random.choice(self.COLORMAPS)
        mpl_cmap = plt.colormaps.get_cmap(cmap)
        path_length = len(self.path)
        indices = np.arange(path_length) / path_length
        colors = mpl_cmap(indices)[:, :3]
        for idx, point in enumerate(self.path):
            self.img[point] = colors[idx]
        return self.img


def benchmark(size, n_runs=5):
    path = [(i, j) for i in range(size[0]) for j in range(size[1])]
    cmap = 'viridis'

    times_old = []
    for _ in range(n_runs):
        start = time.time()
        ColoredPathOld(path, size).get_colored_path(cmap)
        times_old.append(time.time() - start)

    times_new = []
    for _ in range(n_runs):
        start = time.time()
        ColoredPathNew(path, size).get_colored_path(cmap)
        times_new.append(time.time() - start)

    avg_old = np.mean(times_old) * 1000
    avg_new = np.mean(times_new) * 1000
    speedup = avg_old / avg_new

    return avg_old, avg_new, speedup

def verify_correctness():
    size = (128, 128)
    path = [(i, j) for i in range(size[0]) for j in range(size[1])]
    cmap = 'viridis'

    img_old = ColoredPathOld(path, size).get_colored_path(cmap)
    img_new = ColoredPathNew(path, size).get_colored_path(cmap)

    return np.allclose(img_old, img_new)

if __name__ == "__main__":
    print("correctness", verify_correctness())
    sizes = [(128, 128), (256, 256), (512, 512)]
    for size in sizes:
        old, new, speedup = benchmark(size)
        print(f"{size[0]}x{size[1]}: {old:.1f}ms -> {new:.1f}ms ({speedup:.1f}x speedup)")

# ➤ python3 benchmark.py
# correctness True
# 128x128: 114.0ms -> 3.6ms (32.0x speedup)
# 256x256: 456.0ms -> 14.5ms (31.5x speedup)
# 512x512: 1838.9ms -> 55.3ms (33.3x speedup)
```

</details>
